### PR TITLE
Hardening: fix crash-safety and resilience bugs

### DIFF
--- a/Crowdhandler.NETsdk/ApiClient.cs
+++ b/Crowdhandler.NETsdk/ApiClient.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.Caching;
 
@@ -22,6 +23,7 @@ namespace Crowdhandler.NETsdk
         // HttpClient objects in this list, as they may be recycled and used by other threads. For example setting the api key on
         // client.DefaultRequestHeaders would be a bad idea as this could be re-cycled
         internal static LimitedPool<HttpClient> _httpClientPool;
+        private static readonly object _poolLock = new object();
 
         protected string apiUrl;
         protected string publicApiKey;
@@ -41,8 +43,17 @@ namespace Crowdhandler.NETsdk
             const SecurityProtocolType tls13 = (SecurityProtocolType)12288;
             ServicePointManager.SecurityProtocol = tls13 | SecurityProtocolType.Tls12;
 
-            var fivemins = new TimeSpan(0, 5, 0);
-            _httpClientPool = new LimitedPool<HttpClient>(CreateClientObject, client => client.Dispose(), fivemins);
+            if (_httpClientPool == null)
+            {
+                lock (_poolLock)
+                {
+                    if (_httpClientPool == null)
+                    {
+                        var fivemins = new TimeSpan(0, 5, 0);
+                        _httpClientPool = new LimitedPool<HttpClient>(CreateClientObject, client => client.Dispose(), fivemins);
+                    }
+                }
+            }
         }
         protected HttpClient CreateClientObject()
         {
@@ -188,21 +199,59 @@ namespace Crowdhandler.NETsdk
 
         protected string doRequest(HttpRequestMessage request)
         {
-            int maxRetries = 5;
-            int delay = 1000; // Delay in milliseconds
+            int maxRetries = 2;
+            int delay = 0; // No delay between retries — total worst case is 2 x apiRequestTimeout (default 3s = 6s total)
+
+            // Capture request details upfront so we can build a fresh HttpRequestMessage per attempt.
+            // HttpRequestMessage can only be sent once — reusing it throws InvalidOperationException.
+            var method = request.Method;
+            var uri = request.RequestUri;
+            var headers = new List<KeyValuePair<string, IEnumerable<string>>>();
+            foreach (var header in request.Headers)
+            {
+                headers.Add(header);
+            }
+            byte[] bodyBytes = null;
+            string contentType = null;
+            if (request.Content != null)
+            {
+                bodyBytes = request.Content.ReadAsByteArrayAsync().Result;
+                contentType = request.Content.Headers.ContentType?.ToString();
+            }
 
             for (int i = 0; i < maxRetries; i++)
             {
                 try
                 {
+                    var msg = new HttpRequestMessage(method, uri);
+                    foreach (var header in headers)
+                    {
+                        msg.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                    if (bodyBytes != null)
+                    {
+                        msg.Content = new ByteArrayContent(bodyBytes);
+                        if (contentType != null)
+                        {
+                            msg.Content.Headers.Remove("Content-Type");
+                            msg.Content.Headers.TryAddWithoutValidation("Content-Type", contentType);
+                        }
+                    }
+
                     using (var httpClientContainer = _httpClientPool.Get())
                     {
                         HttpClient client = httpClientContainer.Value;
-                        var task = Task.Run(() => client.SendAsync(request));
+                        var task = Task.Run(() => client.SendAsync(msg));
                         task.Wait();
-                        var response = task.Result;
+                        using (var response = task.Result)
+                        {
+                            if ((int)response.StatusCode >= 400)
+                            {
+                                throw new HttpRequestException($"CrowdHandler API returned HTTP {(int)response.StatusCode}");
+                            }
 
-                        return response.Content.ReadAsStringAsync().Result;
+                            return response.Content.ReadAsStringAsync().Result;
+                        }
                     }
                 }
                 catch (Exception ex) //Catch all exceptions
@@ -213,7 +262,7 @@ namespace Crowdhandler.NETsdk
                         throw;
                     }
 
-                    System.Threading.Thread.Sleep(delay * (i + 1)); // Increase the delay with each retry.
+                    Thread.Sleep(delay * (i + 1)); // Increase the delay with each retry.
                 }
             }
             return null;

--- a/Crowdhandler.NETsdk/Crowdhandler.NETsdk.csproj
+++ b/Crowdhandler.NETsdk/Crowdhandler.NETsdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
     <Authors>Crowdhandler</Authors>
     <Company>Crowdhandler</Company>
     <Product>Crowdhandler</Product>

--- a/Crowdhandler.NETsdk/GateKeeper.cs
+++ b/Crowdhandler.NETsdk/GateKeeper.cs
@@ -436,7 +436,15 @@ namespace Crowdhandler.NETsdk
             {
                 return null;
             }
-            return Newtonsoft.Json.JsonConvert.DeserializeObject<CookieData>(JSONCookieData);
+            try
+            {
+                return Newtonsoft.Json.JsonConvert.DeserializeObject<CookieData>(JSONCookieData);
+            }
+            catch (Exception)
+            {
+                // Malformed or tampered cookie — treat as no cookie
+                return null;
+            }
         }
 
         /// <summary>
@@ -460,10 +468,25 @@ namespace Crowdhandler.NETsdk
                 switch (room.patternType)
                 {
                     case "regex":
-                        Regex reg = new Regex(room.urlPattern);
-                        matched = reg.IsMatch(path);
+                        if (string.IsNullOrEmpty(room.urlPattern))
+                        {
+                            break;
+                        }
+                        try
+                        {
+                            Regex reg = new Regex(room.urlPattern);
+                            matched = reg.IsMatch(path);
+                        }
+                        catch (ArgumentException)
+                        {
+                            // Invalid regex from API — skip this room
+                        }
                         break;
                     case "contains":
+                        if (string.IsNullOrEmpty(room.urlPattern))
+                        {
+                            break;
+                        }
                         matched = path.Contains(room.urlPattern);
                         break;
                     case "all":
@@ -497,6 +520,10 @@ namespace Crowdhandler.NETsdk
                 }
 
                 // Check if the path matches the checkout URL pattern
+                if (string.IsNullOrEmpty(room.checkout))
+                {
+                    continue;
+                }
                 try
                 {
                     Regex checkoutRegex = new Regex(room.checkout);
@@ -505,9 +532,9 @@ namespace Crowdhandler.NETsdk
                         return "busted"; // Checkout pattern matched
                     }
                 }
-                catch (ArgumentException ex)
+                catch (ArgumentException)
                 {
-                    // Handle or log invalid regex pattern here
+                    // Invalid regex from API — skip this room
                 }
             }
             return "not-busted"; // No matching checkout pattern found

--- a/CrowdhandlerMVCSDK/CrowdHandlerFilterAttribute.cs
+++ b/CrowdhandlerMVCSDK/CrowdHandlerFilterAttribute.cs
@@ -80,7 +80,7 @@ namespace Crowdhandler.MVCSDK
             if (GatekeeperType == null)
             {
                 // If the api properties are not set on this object they should be null, and therefore allow the gatekeeper defaults to kick in
-                return new GateKeeper(ApiEndpoint, PublicApiKey, PrivateApiKey, Exclusions, APIRequestTimeout, RoomCacheTTL);
+                return new GateKeeper(PublicApiKey, PrivateApiKey, ApiEndpoint, null, Exclusions, APIRequestTimeout, RoomCacheTTL, SafetyNetSlug);
             }
 
             if (!typeof(IGateKeeper).IsAssignableFrom(GatekeeperType))

--- a/CrowdhandlerMVCSDK/Crowdhandler.MVCSDK.csproj
+++ b/CrowdhandlerMVCSDK/Crowdhandler.MVCSDK.csproj
@@ -10,7 +10,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.0.9</Version>
+    <Version>1.0.11</Version>
     <PackageIcon>branding.png</PackageIcon>
     <AssemblyVersion></AssemblyVersion>
     <RepositoryUrl>https://github.com/Crowdhandler/crowdhandler-dotnet-integration</RepositoryUrl>


### PR DESCRIPTION
- Fix constructor parameter ordering in CrowdhandlerFilterAttribute
- Fix HttpRequestMessage reuse in retry loop (retries were always failing)
- Fix static HttpClient pool being overwritten on every request
- Reduce retry to 1 with 6s max total wait time
- Handle malformed cookies gracefully instead of crashing
- Check HTTP status codes on API responses (4xx/5xx)
- Guard against null/invalid regex in MatchRoom and IsCheckoutBuster
- Bump both packages to 1.0.11